### PR TITLE
Add group parameter to rails initializer to run on asset precompilation

### DIFF
--- a/lib/sprockets/engine.rb
+++ b/lib/sprockets/engine.rb
@@ -1,7 +1,7 @@
 if defined?(Rails)
   module Sprockets
     class CommonJSEngine < Rails::Engine
-      initializer :setup_commonjs do |app|
+      initializer :setup_commonjs, :group => :assets do |app|
         app.assets.register_postprocessor 'application/javascript', CommonJS
       end
     end


### PR DESCRIPTION
Initializers in config/initializers/\* aren't executed on asset precompilation.

This means that there is no way to execute register_postprocesser

```
Rails.application.assets.register_postprocessor 'application/javascript', Sprockets::CommonJS
```

Adding a :group argument to engine.rb so that this is run on asset recompilation.
