### PR TITLE
Improved fixes for issues with wrapping modules in dev mode and with asset precompiling

### DIFF
--- a/lib/sprockets/engine.rb
+++ b/lib/sprockets/engine.rb
@@ -1,7 +1,7 @@
 if defined?(Rails)
   module Sprockets
     class CommonJSEngine < Rails::Engine
-      initializer :setup_commonjs, :group => :assets do |app|
+      initializer :setup_commonjs, :after => "sprockets.environment", :group => :all do |app|
         app.assets.register_postprocessor 'application/javascript', CommonJS
       end
     end


### PR DESCRIPTION
My co-founder continued to have issues with registering the post processor on my machine and his. After putzing around with it some more, I found the approach taken by the handlebars-assets gem worked on both my machine and his in both environments. Submitting this as an improvement over my last pull request.

As a side note, I really wish sprockets wasn't so complicated that only like four people really understood how it works.
