### PR TITLE
Some cleanup

### DIFF
--- a/lib/sprockets-commonjs.rb
+++ b/lib/sprockets-commonjs.rb
@@ -1,2 +1,2 @@
 require 'sprockets/commonjs'
-require 'sprockets/engine'
+require 'sprockets/commonjs/engine'

--- a/lib/sprockets-commonjs.rb
+++ b/lib/sprockets-commonjs.rb
@@ -1,0 +1,2 @@
+require 'sprockets/commonjs'
+require 'sprockets/engine'

--- a/lib/sprockets/commonjs.rb
+++ b/lib/sprockets/commonjs.rb
@@ -34,4 +34,4 @@ module Sprockets
   end
 end
 
-require 'sprockets/engine'
+require 'sprockets/commonjs/engine'

--- a/lib/sprockets/commonjs.rb
+++ b/lib/sprockets/commonjs.rb
@@ -9,11 +9,12 @@ module Sprockets
                      '%s' +
                      ";}});\n"
 
-    self.default_mime_type = 'application/javascript'
-
-    def self.default_namespace
-      'this.require'
+    class << self
+      attr_accessor :default_namespace
     end
+
+    self.default_mime_type = 'application/javascript'
+    self.default_namespace = 'this.require'
 
     def prepare
       @namespace = self.class.default_namespace

--- a/lib/sprockets/commonjs.rb
+++ b/lib/sprockets/commonjs.rb
@@ -20,8 +20,6 @@ module Sprockets
       @namespace = self.class.default_namespace
     end
 
-    attr_reader :namespace
-
     def evaluate(scope, locals, &block)
       if scope.pathname.basename.to_s.include?('.module')
         path = scope.logical_path.inspect
@@ -31,6 +29,11 @@ module Sprockets
         data
       end
     end
+
+    private
+
+    attr_reader :namespace
+
   end
 end
 

--- a/lib/sprockets/commonjs.rb
+++ b/lib/sprockets/commonjs.rb
@@ -3,6 +3,12 @@ require 'tilt'
 
 module Sprockets
   class CommonJS < Tilt::Template
+
+    DEFINE_WRAPPER = '%s.define({%s:' +
+                     'function(exports, require, module){' +
+                     '%s' +
+                     ";}});\n"
+
     self.default_mime_type = 'application/javascript'
 
     def self.default_namespace
@@ -18,15 +24,8 @@ module Sprockets
     def evaluate(scope, locals, &block)
       if scope.pathname.basename.to_s.include?('.module')
         path = scope.logical_path.inspect
-
         scope.require_asset 'sprockets/commonjs'
-
-        code = ''
-        code << "#{namespace}.define({#{path}:"
-        code << 'function(exports, require, module){'
-        code << data
-        code << ";}});\n"
-        code
+        WRAPPER % [ namespace, path, data ]
       else
         data
       end

--- a/lib/sprockets/commonjs.rb
+++ b/lib/sprockets/commonjs.rb
@@ -16,6 +16,8 @@ module Sprockets
     self.default_mime_type = 'application/javascript'
     self.default_namespace = 'this.require'
 
+    protected
+
     def prepare
       @namespace = self.class.default_namespace
     end

--- a/lib/sprockets/commonjs.rb
+++ b/lib/sprockets/commonjs.rb
@@ -23,7 +23,7 @@ module Sprockets
     end
 
     def evaluate(scope, locals, &block)
-      if common_js_module?(scope)
+      if commonjs_module?(scope)
         path = scope.logical_path.inspect
         scope.require_asset 'sprockets/commonjs'
         WRAPPER % [ namespace, path, data ]
@@ -36,7 +36,7 @@ module Sprockets
 
     attr_reader :namespace
 
-    def common_js_module?(scope)
+    def commonjs_module?(scope)
       scope.pathname.basename.to_s.include?('.module')
     end
 

--- a/lib/sprockets/commonjs.rb
+++ b/lib/sprockets/commonjs.rb
@@ -21,7 +21,7 @@ module Sprockets
     end
 
     def evaluate(scope, locals, &block)
-      if scope.pathname.basename.to_s.include?('.module')
+      if common_js_module?(scope)
         path = scope.logical_path.inspect
         scope.require_asset 'sprockets/commonjs'
         WRAPPER % [ namespace, path, data ]
@@ -33,6 +33,10 @@ module Sprockets
     private
 
     attr_reader :namespace
+
+    def common_js_module?(scope)
+      scope.pathname.basename.to_s.include?('.module')
+    end
 
   end
 end

--- a/lib/sprockets/commonjs/engine.rb
+++ b/lib/sprockets/commonjs/engine.rb
@@ -1,0 +1,15 @@
+require 'sprockets/commonjs'
+
+if defined?(Rails)
+  module Sprockets
+    class CommonJS
+
+      class Engine < Rails::Engine
+        initializer :setup_commonjs, :after => "sprockets.environment", :group => :all do |app|
+          app.assets.register_postprocessor 'application/javascript', CommonJS
+        end
+      end
+
+    end
+  end
+end

--- a/lib/sprockets/engine.rb
+++ b/lib/sprockets/engine.rb
@@ -1,9 +1,0 @@
-if defined?(Rails)
-  module Sprockets
-    class CommonJSEngine < Rails::Engine
-      initializer :setup_commonjs, :after => "sprockets.environment", :group => :all do |app|
-        app.assets.register_postprocessor 'application/javascript', CommonJS
-      end
-    end
-  end
-end


### PR DESCRIPTION
1. move `sprockets/engine` to `sprockets/commonjs/engine` so it doesn't conflict with any other Sprockets Engines
2. add `Sprockets::CommonJS.default_namespace=` so clients don't have to monkey-patch to change it
3. make `Sprockets::CommonJS#prepare` and `#evaluate` protected, like they are for `Tilt::Template` (the parent class)
4. make helper method `Sprockets::CommonJS#namespace` private
5. extract helper method `Sprockets::CommonJS#common_js_module?`
6. extract the CommonJS module definition JavaScript into a constant
