### PR TITLE
Update sprockets dependency to make it comparabile with the newest rails (v 3.2.9)

### DIFF
--- a/sprockets-commonjs.gemspec
+++ b/sprockets-commonjs.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
-  s.add_runtime_dependency "sprockets", "~>2.1.2"
+  s.add_runtime_dependency "sprockets", "~>2.2.1"
 end


### PR DESCRIPTION
This push request is related to https://github.com/maccman/sprockets-commonjs/issues/14
I've just update this dependency in out large application and everything work. I think it's 100% safe to update.
