### PR TITLE
Ensure reference to Rails::Engine is not scoped to Sprockets

### DIFF
--- a/lib/sprockets/commonjs/engine.rb
+++ b/lib/sprockets/commonjs/engine.rb
@@ -4,7 +4,7 @@ if defined?(Rails)
   module Sprockets
     class CommonJS
 
-      class Engine < Rails::Engine
+      class Engine < ::Rails::Engine
         initializer :setup_commonjs, :after => "sprockets.environment", :group => :all do |app|
           app.assets.register_postprocessor 'application/javascript', CommonJS
         end


### PR DESCRIPTION
This will just ensure reference to Rails::Engine will not be scoped to Sprockets

``` ruby
`<class:CommonJS>': uninitialized constant Sprockets::Rails::Engine (NameError)
```
