### PR TITLE
Fix module contract for modules that assign exports

### DIFF
--- a/lib/assets/javascripts/sprockets/commonjs.js
+++ b/lib/assets/javascripts/sprockets/commonjs.js
@@ -11,6 +11,7 @@
         module = {id: path, exports: {}};
         cache[path] = module.exports;
         fn(module.exports, function(name) {
+          cache[path] = module.exports;
           return require(name, dirname(path));
         }, module);
         return cache[path] = module.exports;


### PR DESCRIPTION
This change makes sprockets-commonjs compliant with the "Module context" contract, paragraph 1.3: "[...]the object returned by "require" must contain at least the exports that the foreign module has prepared[...]".

Some code bases use the (not yet specified/clarified in CommonJS) method of assigning exports to export things. If, in these code bases, they then go on to require more code that depends on the previous module's exports, that new code won't see these exports unless we re-cache the exports here, thus breaking that paragraph above.
