### PR TITLE
Fix sprockets-commonjs for non rails environment, related to #19

### DIFF
--- a/lib/sprockets/commonjs/engine.rb
+++ b/lib/sprockets/commonjs/engine.rb
@@ -12,4 +12,9 @@ if defined?(Rails)
 
     end
   end
+else
+  module Sprockets
+    register_postprocessor 'application/javascript', CommonJS
+    append_path File.expand_path('../../../assets/javascripts', __FILE__)
+  end
 end

--- a/test/sprockets_commonjs_test.rb
+++ b/test/sprockets_commonjs_test.rb
@@ -11,7 +11,6 @@ class SprocketsCommonjsTest < Test::Unit::TestCase
 
   def setup
     env = Sprockets::Environment.new
-    env.register_postprocessor 'application/javascript', Sprockets::CommonJS
     env.append_path TEST_DIR
     env.append_path LIB_DIR
     outfile = Tempfile.new('sprockets-output')


### PR DESCRIPTION
Please release a new version of sprockets-commonjs.

And also bump the version of sprockets-commonjs in catapult.

Thank you for your fantastic gem. :+1: 
