### PR TITLE
can now have a custom namespace in the JS file

### DIFF
--- a/lib/assets/javascripts/sprockets/commonjs.js.erb
+++ b/lib/assets/javascripts/sprockets/commonjs.js.erb
@@ -1,5 +1,5 @@
 (function() {
-  if (!this.require) {
+  if (!<%= Sprockets::CommonJS.default_namespace %>) {
     var modules = {}, cache = {};
 
     var require = function(name, root) {
@@ -43,19 +43,19 @@
       return path.split('/').slice(0, -1).join('/');
     };
 
-    this.require = function(name) {
+    <%= Sprockets::CommonJS.default_namespace %> = function(name) {
       return require(name, '');
     };
 
-    this.require.define = function(bundle) {
+    <%= Sprockets::CommonJS.default_namespace %>.define = function(bundle) {
       for (var key in bundle) {
         modules[key] = bundle[key];
       }
     };
 
-    this.require.modules = modules;
-    this.require.cache   = cache;
+    <%= Sprockets::CommonJS.default_namespace %>.modules = modules;
+    <%= Sprockets::CommonJS.default_namespace %>.cache   = cache;
   }
 
-  return this.require;
+  return <%= Sprockets::CommonJS.default_namespace %>;
 }).call(this);


### PR DESCRIPTION
Sometimes you don't want to use "require" due to conflicts - this allows you to set:

``` ruby
Sprockets::CommonJS.default_namespace = "this.different_require"
```

so that you can use "different_require" in the javascript too.
