### PR TITLE
Updated sprockets dependency for Rails 4.2.0.beta2.

### DIFF
--- a/sprockets-commonjs.gemspec
+++ b/sprockets-commonjs.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
-  s.add_runtime_dependency "sprockets", "~>2.10.1"
+  s.add_runtime_dependency "sprockets", "~>2.12"
 end


### PR DESCRIPTION
Attempting to use `sprockets-commonjs` with `Rails 4.2.0.beta2` results in a unresolvable dependency conflict.
