### PR TITLE
Allow version 3 of sprockets to be used.

### DIFF
--- a/sprockets-commonjs.gemspec
+++ b/sprockets-commonjs.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
-  s.add_runtime_dependency "sprockets",     "~> 2.1"
+  s.add_runtime_dependency "sprockets",     ">= 2.1", "< 4"
   s.add_development_dependency 'appraisal', '~> 0.5.1'
 end


### PR DESCRIPTION
I believe this is an acceptable version range for the sprockets dependency. No breaking changes to what this gem does seem to have been introduced in sprockets v3 and it's working great for us with the new major version. The sass-rails gem has a similar version lock, for what it's worth.

https://github.com/rails/sass-rails/blob/master/sass-rails.gemspec#L19
