### PR TITLE
Support wrapping modules with a line comment as the last line.

### DIFF
--- a/lib/sprockets/commonjs.rb
+++ b/lib/sprockets/commonjs.rb
@@ -6,7 +6,7 @@ module Sprockets
     WRAPPER = '%s.define({%s:' +
                      'function(exports, require, module){' +
                      '%s' +
-                     ";}});\n"
+                     "\n}});\n"
 
     EXTENSIONS = %w{.module .cjs}
 


### PR DESCRIPTION
Using a newline instead of a semicolon to terminate the last statement of a module means that any line comment on the last line will no longer encompass the `}});` appended to the module, which would previously result in a syntax error.
